### PR TITLE
Added Media Queries for Mobile (less than 376px)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,4 +1,4 @@
-/*My Edits: 1. Created flex containers for header and nav ul. 2. Targeted margin-left selector 3. Commented out some of starter code (to be replaced) 4. Added styling and positioning for nav a. 5. Removed list type for ul (all of page). 6. Started to add comments to explain CSS rules. 7. Added styling to h1. 8. Created Grid for About Me, positioned items within it and formatted image size, and text size (in about-text). 9. Added var function for colours and font family. 10. Created Grid for Work, positioned items within it and added background images to items. 11. Created Grid for Work Headings (nested in Work grid), positioned items within it and changed colours, width etc. 12. Added credit reference for adapted code. 13. Adding styling to links in Work section (removed underlining) 14. Repositioned Work header in Work grid 15. Created grid for Contact Me section, added font-family to Contact section, created flex containder for contact links, set these items as inline and added styling to links 16. Repositioned Contact header in Contact grid. 17. Added media queries for medium screen sizes (up to 1007px)*/
+/*My Edits: 1. Created flex containers for header and nav ul. 2. Targeted margin-left selector 3. Commented out some of starter code (to be replaced) 4. Added styling and positioning for nav a. 5. Removed list type for ul (all of page). 6. Started to add comments to explain CSS rules. 7. Added styling to h1. 8. Created Grid for About Me, positioned items within it and formatted image size, and text size (in about-text). 9. Added var function for colours and font family. 10. Created Grid for Work, positioned items within it and added background images to items. 11. Created Grid for Work Headings (nested in Work grid), positioned items within it and changed colours, width etc. 12. Added credit reference for adapted code. 13. Adding styling to links in Work section (removed underlining) 14. Repositioned Work header in Work grid 15. Created grid for Contact Me section, added font-family to Contact section, created flex containder for contact links, set these items as inline and added styling to links 16. Repositioned Contact header in Contact grid. 17. Added media queries for medium screen sizes (up to 1007px) 18. Added media queries for mobile (less than 376px)*/
 
 /*var() function for colours and font family (for use across page where variable added)*/
 :root {
@@ -221,7 +221,9 @@ h1 {
 
 /* **Media Queries** */
 
-/* *Medium (641px to 1007px)* */
+/* *Medium (up to 1007px)* */
+
+/*No seperate media queries for Small (640px to 375px), as all elements displayed at Medium are still displayed at Small. Therefore below media queries actually apply for 376px to 1007px*/
 
 @media screen and (max-width: 1007px) {
   /*Reduces font size in Header/Nav Bar*/
@@ -249,5 +251,24 @@ h1 {
   /*Reduces font size of links in Contact*/
   #contact a {
     font-size: 100%;
+  }
+}
+
+/* *Mobile (smaller than 376px)* */
+
+@media screen and (max-width: 375px) {
+  /*No longer displays Header/Nav Bar and main headers in About, Work and Contact*/
+  header,.about-header, #work-header, .contact-header  {
+    display: none;
+  }
+
+  /*Repositions text (takes up three coloums now)*/
+   .about-text {
+    grid-column: 1 / span 3;
+  }
+
+  /*Repositions Contact links (in unordered list) (take up two coloums now)*/
+  #contact ul {
+    grid-column: 1 / span 2;
   }
 }


### PR DESCRIPTION
CSS: Added media queries for less than 376px, including: no longer displays Header/Nav Bar nor main headers in About, Work and Contact, repositioning text in About (now takes up three columns) and repositioning links in Contact links (now take up two columns).
